### PR TITLE
Fix display of individual quotes

### DIFF
--- a/porick/templates/browse.html
+++ b/porick/templates/browse.html
@@ -132,6 +132,8 @@
                 </div>
             </div>
         {% endfor %}
-        {{render_pagination(pagination)}}
+        {% if pagination.items | length > 1 %}
+          {{render_pagination(pagination)}}
+        {% endif %}
     {% endif %}
 {% endblock %}

--- a/porick/views.py
+++ b/porick/views.py
@@ -44,8 +44,8 @@ def browse(area=None, quote_id=None):
     g.page = area or 'browse'
     quotes = Quote.query
     if quote_id is not None:
-        quotes = quotes.filter(Quote.id == quote_id).first()
-        if not quotes or quotes.status != QSTATUS['approved']:
+        quotes = quotes.filter(Quote.id == quote_id)
+        if not quotes or quotes[0].status != QSTATUS['approved']:
             abort(404)
     else:
         try:
@@ -55,10 +55,10 @@ def browse(area=None, quote_id=None):
             # don't have a specific filter.
             quotes = quotes.filter(Quote.status == QSTATUS['approved'])
         quotes = quotes.order_by(AREA_ORDER_MAP.get(area, DEFAULT_ORDER))
-        if area == 'random':
-            quotes = quotes.first()
     pagination = quotes.paginate(
         g.current_page, app.config['QUOTES_PER_PAGE'], error_out=True)
+    if quote_id or area == 'random':
+        pagination.items = pagination.items[:1]
     return render_template('/browse.html', pagination=pagination)
 
 


### PR DESCRIPTION
The templates expect a Paginator object, with `paginator.items` being the quotes they'll iterate over to display.
Creation of this object fails when we've done a `.first()` on the query, since the `quotes` object is then an instance of `Quote`, and not an SQLAlchemy `ResultProxy` or whatever.

Why paginate and then overwrite `paginator.items` with a list of a single item? Well, the other options are:
- use a `.limit(1)` on both of the queries. This doesn't work, because the paginator then does an `order_by` afterwards.
- Pass in the quotes along with the paginator object to the template. This is how Pylons Porick did it and it's ugly (and would necessitate rewriting the templates a little)
- Create a fake pagination class, which is instantiated in both of these cases. This would work, but it's hacky. 

I've concluded that this is most likely the cleanest and best solution, even if it may be a little inefficient in the 'random' case. This inefficiency could be improved by doing something like

```
pagination = quotes.paginate(
    g.current_page, 1 if area == 'random' else app.config['QUOTES_PER_PAGE'], error_out=True)
```

but since that makes the code far less readable, and it's essentially a premature optimisation for a bullshit irc quotes app, I'm leaving it out.
