### PR TITLE
Add fast implementation of the tag cloud

### DIFF
--- a/porick/templates/tagcloud.html
+++ b/porick/templates/tagcloud.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block body_content %}
+    <div class="tags cloud">
+        {% for tag, size in tagcloud.iteritems() %}
+            <a href="{{url_for('browse_by_tags', tag=tag)}}">
+                <span class="label label-important" style="font-size:{{size + 10}}px;">
+                    {{tag}}
+                </span>
+            </a>
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/porick/views.py
+++ b/porick/views.py
@@ -82,7 +82,7 @@ def _generate_tagcloud(tags):
 
     cloud = {}
     for tag_id, count in counts.iteritems():
-        tag = tags[tag_id]
+        tag = tags.get(tag_id)
         if tag:
             cloud[tag] = math.log(count, math.e/2)
 

--- a/porick/views.py
+++ b/porick/views.py
@@ -1,5 +1,8 @@
 import datetime
 import hashlib
+import math
+
+from collections import defaultdict
 
 from flask import (
     abort, render_template, flash, g, request, redirect, make_response, url_for)
@@ -8,9 +11,11 @@ from . import app
 from .lib import current_page, authenticate, validate_signup, create_user
 from .models import (
     AREA_ORDER_MAP,
+    db,
     DEFAULT_ORDER,
     QSTATUS,
     Quote,
+    QuoteToTag,
     Tag,
     User,
 )
@@ -67,26 +72,42 @@ def browse(area=None, quote_id=None):
         pagination.items = pagination.items[:1]
     return render_template('/browse.html', pagination=pagination)
 
+def _generate_tagcloud(tags):
+    counts = defaultdict(int)
+    quote_to_tag = db.session.query(QuoteToTag).all()
+    tags = {t.id: t.tag for t in Tag.query.all()}
+
+    for quote_id, tag_id in quote_to_tag:
+        counts[tag_id] += 1
+
+    cloud = {}
+    for tag_id, count in counts.iteritems():
+        tag = tags[tag_id]
+        if tag:
+            cloud[tag] = math.log(count, math.e/2)
+
+    return cloud
 
 @app.route('/browse/tags')
 @app.route('/browse/tags/<tag>')
 def browse_by_tags(tag=None, page=None):
     if not tag:
-        raise NotImplementedError()
+        tags = Tag.query.all()
+        return render_template('tagcloud.html', tagcloud=_generate_tagcloud(tags))
 
-    tag = Tag.query.filter(Tag.tag == tag).one()
-    q = Quote.query
-    q = q.filter(Quote.tags.contains(tag))
-    q = q.filter(Quote.status == QSTATUS['approved'])
-    q = q.order_by(Quote.submitted.desc())
+    else:
+        tag = Tag.query.filter(Tag.tag == tag).one()
+        q = Quote.query
+        q = q.filter(Quote.tags.contains(tag))
+        q = q.filter(Quote.status == QSTATUS['approved'])
+        q = q.order_by(Quote.submitted.desc())
 
-    pagination = q.paginate(
-        g.current_page,
-        app.config['QUOTES_PER_PAGE'],
-        error_out=True
-    )
-
-    return render_template('/browse.html', pagination=pagination)
+        pagination = q.paginate(
+            g.current_page,
+            app.config['QUOTES_PER_PAGE'],
+            error_out=True
+        )
+        return render_template('/browse.html', pagination=pagination)
 
 @app.route('/search', methods=['POST'])
 def search():


### PR DESCRIPTION
Resolves #15.

The original version performed _n_ + 1 queries, where _n_ is the number of tags we have stored
(`SELECT *` on the `tags` table, then a `SELECT COUNT...` on the `quotes_to_tags` table for each tag).

This version performs two queries, regardless of how many tags we have stored, and then computes the counts in memory.
(`SELECT *` on the `tags` table, then `SELECT *` on the `quotes_to_tags` table).
- [x] @kopf 
- [x] @johnlunney 
