### PR TITLE
py-bcrypt a much less painful dependency than bcrypt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Flask
 MySQL-python
 SQLAlchemy
-bcrypt
+py-bcrypt
 Flask-SQLAlchemy
 mock


### PR DESCRIPTION
https://teamtreehouse.com/community/im-trying-to-install-flaskbcrypt-on-mac-but-getting-error-command-usrbinclang-failed-with-exit-status-1

@kopf 
