### PR TITLE
Implement #13, password reset page

### DIFF
--- a/porick/lib.py
+++ b/porick/lib.py
@@ -2,13 +2,49 @@ import bcrypt
 from datetime import datetime, timedelta
 from functools import wraps
 import re
+import smtplib
+
+from email.mime.text import MIMEText
 
 from flask import request, g, abort, redirect, url_for
 from sqlalchemy import or_
 
 from models import ReportedQuotes, Quote, QSTATUS, User
 from porick import db
-from settings import PASSWORD_SALT, USER_REPORT_LIMIT
+from settings import PASSWORD_SALT, USER_REPORT_LIMIT, SERVER_DOMAIN, PASSWORD_RESET_REQUEST_EXPIRY, SMTP_REPLYTO, SMTP_SERVER
+
+
+
+reset_password_text = """
+Hi,
+
+A password reset has been requested for your account on Porick.
+
+To reset your password, please click the link below.
+
+http://{server_domain}/reset_password?key={key}
+
+This URL will be valid for {validity}.
+
+If you did not initiate this password reset then you may simply disregard this email.
+
+Cheers,
+Porick
+
+"""
+
+def send_reset_password_email(user_email, key):
+    validity = '{} hour{}'.format(PASSWORD_RESET_REQUEST_EXPIRY, '' if PASSWORD_RESET_REQUEST_EXPIRY == 1 else 's')
+    msg = MIMEText(reset_password_text.format(server_domain=SERVER_DOMAIN, key=key, validity=validity))
+    msg['To'] = user_email
+    msg['From'] = SMTP_REPLYTO
+    msg['Subject'] = 'Porick password reset request'
+    s = smtplib.SMTP(SMTP_SERVER)
+    s.sendmail(
+        SMTP_REPLYTO, [user_email],
+        msg.as_string()
+    )
+    s.quit()
 
 def current_page(default=1):
     try:
@@ -17,11 +53,14 @@ def current_page(default=1):
         return default
 
 
+def hash_password(plaintext):
+    return bcrypt.hashpw(plaintext.encode('utf-8'), PASSWORD_SALT)
+
 def authenticate(username, password):
     user = User.query.filter(User.username == username).first()
     if not user:
         return False
-    elif bcrypt.hashpw(password.encode('utf-8'), PASSWORD_SALT) == user.password:
+    elif hash_password(password) == user.password:
         return user
     else:
         return False

--- a/porick/lib.py
+++ b/porick/lib.py
@@ -15,7 +15,7 @@ from settings import PASSWORD_SALT, USER_REPORT_LIMIT, SERVER_DOMAIN, PASSWORD_R
 
 
 
-reset_password_text = """
+PASSWORD_RESET_TEXT = """
 Hi,
 
 A password reset has been requested for your account on Porick.
@@ -34,8 +34,8 @@ Porick
 """
 
 def send_reset_password_email(user_email, key):
-    validity = '{} hour{}'.format(PASSWORD_RESET_REQUEST_EXPIRY, '' if PASSWORD_RESET_REQUEST_EXPIRY == 1 else 's')
-    msg = MIMEText(reset_password_text.format(server_domain=SERVER_DOMAIN, key=key, validity=validity))
+    validity = '{} hour{}'.format(PASSWORD_RESET_REQUEST_EXPIRY, 's' if PASSWORD_RESET_REQUEST_EXPIRY > 1 else '')
+    msg = MIMEText(PASSWORD_RESET_TEXT.format(server_domain=SERVER_DOMAIN, key=key, validity=validity))
     msg['To'] = user_email
     msg['From'] = SMTP_REPLYTO
     msg['Subject'] = 'Porick password reset request'
@@ -111,7 +111,7 @@ def create_user(username, password, email):
         elif conflicts.username == username:
             raise NameError('Sorry! That username is already taken.')
 
-    hashed_pass = bcrypt.hashpw(password.encode('utf-8'), PASSWORD_SALT)
+    hashed_pass = hash_password(password)
     new_user = User()
     new_user.username = username
     new_user.password = hashed_pass

--- a/porick/settings/settings.example
+++ b/porick/settings/settings.example
@@ -6,3 +6,9 @@ SECRET_KEY = 'Yet another, different, random string, to be kept secret.'
 QUOTES_PER_PAGE = 10
 COOKIE_LIFETIME = 90 # in days
 USER_REPORT_LIMIT = 5 # Max number of reports a user can make before they're processed
+PASSWORD_RESET_REQUEST_EXPIRY = 2 # in hours
+
+# Settings for emailing password resets
+SMTP_REPLYTO = 'root'
+SMTP_SERVER = 'localhost'
+SERVER_DOMAIN = 'localhost'

--- a/porick/templates/pw_reset/request.html
+++ b/porick/templates/pw_reset/request.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+
+{% block body_content %}
+    <form class="well create_new_quote" action="{{url_for('reset_password')}}" method="post">
+        <label class="control-label" for="email">Email address:</label>
+        <div class="controls">
+            <input type="text" class="input-xlarge" id="email" name="email">
+        </div>
+        <div>
+            <button type="submit" class="btn btn-primary">Reset Password</button>
+        </div>
+    </form>
+{% endblock %}

--- a/porick/templates/pw_reset/set.html
+++ b/porick/templates/pw_reset/set.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block body_content %}
+    <form class="well create_new_quote" action="{{url_for('reset_password', key=key)}}" method="post">
+        <label class="control-label" for="password">Password:</label>
+        <div class="controls">
+            <input type="password" class="input-xlarge" id="password" name="password">
+        </div>
+
+        <label class="control-label" for="password_confirm">Password (confirm):</label>
+        <div class="controls">
+            <input type="password" class="input-xlarge" id="password_confirm" name="password_confirm">
+        </div>
+        <div>
+            <button type="submit" class="btn btn-primary">Set Password</button>
+        </div>
+    </form>
+{% endblock %}
+

--- a/porick/views.py
+++ b/porick/views.py
@@ -287,7 +287,6 @@ def reset_password():
             if valid_password['status']:
                 user = User.query.get(token.user_id)
                 user.password = hash_password(password)
-                db.session.add(user)
 
                 db.session.delete(token)
                 db.session.commit()

--- a/porick/views.py
+++ b/porick/views.py
@@ -1,3 +1,4 @@
+import bcrypt
 import datetime
 import hashlib
 import math
@@ -8,12 +9,12 @@ from flask import (
     abort, render_template, flash, g, request, redirect, make_response, url_for)
 
 from . import app
-from .lib import (current_page, authenticate, authenticated_endpoint,
-                  validate_signup, create_user)
+from .lib import current_page, authenticate, authenticated_endpoint, validate_signup, create_user, hash_password, validate_password, send_reset_password_email
 from .models import (
     AREA_ORDER_MAP,
     db,
     DEFAULT_ORDER,
+    PasswordReset,
     QSTATUS,
     Quote,
     QuoteToTag,
@@ -191,8 +192,7 @@ def signup():
         create_user(username, password, email)
         authenticate(username, password)
         g.user = User.query.filter(User.username == username).first()
-        flash("Your account was successfully created!", 'info')
-        return redirect(url_for('login'))
+        return render_template('/signup_success.html')
     except NameError, e:
         flash(e.__str__(), 'error')
         return render_template('/signup.html')
@@ -221,7 +221,6 @@ def login():
     response.set_cookie('level', str(user.level), expires=expiry)
     return response
 
-
 @app.route('/logout')
 def logout():
     g.page = 'logout'
@@ -233,7 +232,69 @@ def logout():
     flash('Logged out successfully!', 'info')
     return response
 
-
-@app.route('/reset_password')
+@app.route('/reset_password', methods=['GET', 'POST'])
 def reset_password():
-    raise NotImplementedError()
+    if request.method == 'GET':
+        if not request.args.get('key'):
+            return render_template('/pw_reset/request.html')
+
+        token = PasswordReset.query.filter_by(key=request.args['key']).first()
+        if token and token.is_valid:
+            return render_template('/pw_reset/set.html', key=token.key)
+        else:
+            flash('Invalid reset token', 'error')
+            return render_template('/index.html')
+
+
+    elif request.method == 'POST':
+        if not request.args.get('key'):
+        # The user has requested a new token
+            email = request.form['email']
+            user = User.query.filter_by(email=email).first()
+            if not user:
+                flash('Invalid email address provided.', 'error')
+                return render_template('/pw_reset/request.html')
+
+            # If this user already has a valid reset token, don't
+            # let them create a new one until it has expired
+            existing_token = PasswordReset.query.filter_by(user_id=user.id).first()
+            if existing_token:
+                if existing_token.is_valid:
+                    flash('A password reset has already been requested for this user.', 'error')
+                    return render_template('/pw_reset/request.html')
+                else:
+                    db.session.delete(existing_token)
+                    db.session.commit()
+
+            token = PasswordReset(user.id)
+            key = token.key
+            db.session.add(token)
+            db.session.commit()
+            send_reset_password_email(email, key)
+            flash('Password reset email sent!', 'success')
+            return render_template('/index.html')
+
+        else:
+        # Reset the password to what they provided
+            token = PasswordReset.query.filter_by(key=request.args['key']).first()
+            if not token or not token.is_valid:
+                flash('Invalid reset token.', 'error')
+                return render_template('/pw_reset/request.html')
+
+            password = request.form['password']
+            confirm_password = request.form['password_confirm']
+            valid_password = validate_password(password, confirm_password)
+            if valid_password['status']:
+                user = User.query.get(token.user_id)
+                user.password = hash_password(password)
+                db.session.add(user)
+
+                db.session.delete(token)
+                db.session.commit()
+                flash('Password successfully reset. You should now be able to log in.', 'success')
+                return render_template('/login.html')
+            else:
+                flash(valid_password['msg'], 'error')
+                return render_template('/pw_reset/set.html', key=token.key)
+
+


### PR DESCRIPTION
Fix for #13 mostly ported over from pylons, with some refactoring.

One aspect of the original implementation which I don't agree with is the fact that once a user has obtained a password reset token, they are forbidden from requesting another one for as long as the existing one is active, but we don't provide the option to re-send the details of the original one in the meantime. This means that if an email gets lost in email land, the user is out of luck until their token expires. Your thoughts on this would be appreciated.

Changes since the original implementation (roughly) in order of importance:
1. `key` column in `password_reset` table is now expected to be a `char(32)`. This lets us use standard UUIDs as keys and generate them with the `uuid` library, instead of the old `_generate_pw_reset_key()` which sort of reinvented the wheel.
   If you have already imported a DB dump locally, you will need to migrate your `password_resets` table. I did this the lazy way with `ALTER TABLE 'password_resets' DROP COLUMN 'key'; ALTER TABLE 'password_resets' ADD COLUMN 'key' char(32);`
2. Renamed `PasswordResets` mapped class to `PasswordReset`: `Thing()` means "Give me a `Thing`", so writing `blah = PasswordResets()` irritated me.
3. Generating a password reset token, as well as checking if one has expired, is now the responsibility of `PasswordReset`: we have an ORM here, so I figured we should make use of it and start moving some of the "business logic" away from `porick.views` .
4. Validity of reset tokens factored out into a setting.
- [x] @johnlunney 
- [x] @kopf 
