### PR TITLE
Add controversial tab with simple ordering

### DIFF
--- a/porick/models.py
+++ b/porick/models.py
@@ -105,10 +105,10 @@ class Quote(db.Model):
     submitted_by = relationship("User", secondary=QuoteToUser, uselist=False)
     voters       = relationship("VoteToUser")
 
-
 AREA_ORDER_MAP = {
     'best': Quote.rating.desc(),
     'worst': Quote.rating,
-    'random': func.rand()
+    'random': func.rand(),
+    'controversial': Quote.rating/Quote.votes
 }
 DEFAULT_ORDER = Quote.submitted.desc()

--- a/porick/templates/base.html
+++ b/porick/templates/base.html
@@ -35,6 +35,9 @@
                     <li class="{{'active' if g.page == 'random' else ''}}">
                       <a href="{{url_for('browse', area='random')}}">Random</a>
                     </li>
+                    <li class="{{'active' if g.page == 'controversial' else ''}}">
+                      <a href="{{url_for('browse', area='controversial')}}">Controversial</a>
+                    </li>
                     <li class="{{'active' if g.page == 'disapproved' else ''}}">
                       <a href="{{url_for('browse', area='disapproved')}}">Disapproved</a>
                     </li>


### PR DESCRIPTION
This implementation is quite simple. A better approach would be to take the stddev of all of the recorded votes in vote_to_user, but for now this will probably do as it is Chirpy-compliant. 
- High scoring quotes with few downvotes will produce a high score when checking for controversy (tending towards 1.0) 
- Quotes with lots of upvotes and downvotes will have a much lower controversy score, indicating that it's more controversial. 
